### PR TITLE
inference fixes

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,31 +1,12 @@
 version = 1
 
-test_patterns = [
-  'direct/**/tests/test_*.py'
-]
-
-exclude_patterns = [
-
-]
-
 [[analyzers]]
-name = 'python'
-enabled = true
-runtime_version = '3.x.x'
-
-  [analyzers.meta]
-  max_line_length = 119
-
-[[analyzers]]
-name = "docker"
+name = "python"
 enabled = true
 
   [analyzers.meta]
-  dockerfile_paths = [
-    "docker/Dockerfile",
-  ]
+  runtime_version = "3.x.x"
 
-  trusted_registries = [
-    "nvidia",
-    "docker.io"
-  ]
+[[transformers]]
+name = "black"
+enabled = true

--- a/direct/checkpointer.py
+++ b/direct/checkpointer.py
@@ -104,10 +104,10 @@ class Checkpointer:
                 self.logger.warning(f"Requested to load {key}, but this was not stored.")
                 continue
 
-            elif only_models and not re.match(self.model_regex, key):
+            if only_models and not re.match(self.model_regex, key):
                 continue
 
-            elif key.endswith("__") and key.startswith("__"):
+            if key.endswith("__") and key.startswith("__"):
                 continue
 
             self.logger.info(f"Loading {key}...")

--- a/direct/common/tests/test_subsample.py
+++ b/direct/common/tests/test_subsample.py
@@ -25,8 +25,10 @@ def test_fastmri_random_mask_reuse(center_fracs, accelerations, batch_size, dim)
     mask1 = mask_func(shape, seed=123)
     mask2 = mask_func(shape, seed=123)
     mask3 = mask_func(shape, seed=123)
-    assert torch.all(mask1 == mask2)
-    assert torch.all(mask2 == mask3)
+    if not torch.all(mask1 == mask2):
+        raise AssertionError
+    if not torch.all(mask2 == mask3):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -44,7 +46,8 @@ def test_fastmri_random_mask_low_freqs(center_fracs, accelerations, batch_size, 
     mask_shape[-2] = dim
     mask_shape[-3] = dim
 
-    assert list(mask.shape) == mask_shape
+    if list(mask.shape) != mask_shape:
+        raise AssertionError
 
     num_low_freqs_matched = False
     for center_frac in center_fracs:
@@ -52,4 +55,5 @@ def test_fastmri_random_mask_low_freqs(center_fracs, accelerations, batch_size, 
         pad = (dim - num_low_freqs + 1) // 2
         if np.all(mask[pad : pad + num_low_freqs].numpy() == 1):
             num_low_freqs_matched = True
-    assert num_low_freqs_matched
+    if not num_low_freqs_matched:
+        raise AssertionError

--- a/direct/data/datasets.py
+++ b/direct/data/datasets.py
@@ -84,7 +84,7 @@ class FastMRIDataset(H5SliceData):
         sample = super().__getitem__(idx)
 
         if self.pass_attrs:
-            sample["scaling_div"] = sample["attrs"]["max"]
+            sample["scaling_factor"] = sample["attrs"]["max"]
             del sample["attrs"]
 
         sample.update(self.parse_header(sample["ismrmrd_header"]))
@@ -152,8 +152,7 @@ class FastMRIDataset(H5SliceData):
         return mask
 
     @lru_cache(maxsize=None)
-    @staticmethod
-    def parse_header(xml_header):
+    def parse_header(self, xml_header):
         # Borrowed from: https://github.com/facebookresearch/fastMRI/blob/57c0a9ef52924d1ffb30d7b7a51d022927b04b23/fastmri/data/mri_data.py#L136
         header = ismrmrd.xsd.CreateFromDocument(xml_header)  # noqa
         encoding = header.encoding[0]
@@ -347,6 +346,7 @@ def build_dataset_from_input(
     initial_images,
     initial_kspaces,
     filenames_filter,
+    sensitivity_maps,
     data_root,
     pass_dictionaries,
 ):
@@ -366,6 +366,7 @@ def build_dataset_from_input(
     dataset = build_dataset(
         root=data_root,
         filenames_filter=filenames_filter,
+        sensitivity_maps=sensitivity_maps,
         transforms=transforms,
         pass_h5s=pass_h5s,
         pass_dictionaries=pass_dictionaries,

--- a/direct/data/h5_data.py
+++ b/direct/data/h5_data.py
@@ -22,22 +22,20 @@ class H5SliceData(DirectModule, Dataset):
     A PyTorch Dataset class which outputs k-space slices based on the h5 dataformat.
     """
 
-    def __init__(
-        self,
-        root: pathlib.Path,
-        filenames_filter: Optional[List[PathOrString]] = None,
-        regex_filter: Optional[str] = None,
-        dataset_description: Optional[Dict[PathOrString, Any]] = None,
-        metadata: Optional[Dict[PathOrString, Dict]] = None,
-        sensitivity_maps: Optional[PathOrString] = None,
-        extra_keys: Optional[Tuple] = None,
-        pass_attrs: bool = False,
-        text_description: Optional[str] = None,
-        kspace_context: Optional[int] = None,
-        pass_dictionaries: Optional[Dict[str, Dict]] = None,
-        pass_h5s: Optional[Dict[str, List]] = None,
-        slice_data: Optional[slice] = None,
-    ) -> None:
+    def __init__(self,
+                 root: pathlib.Path,
+                 filenames_filter: Optional[List[PathOrString]] = None,
+                 regex_filter: Optional[str] = None,
+                 dataset_description: Optional[Dict[PathOrString, Any]] = None,
+                 metadata: Optional[Dict[PathOrString, Dict]] = None,
+                 sensitivity_maps: Optional[PathOrString] = None,
+                 extra_keys: Optional[Tuple] = None,
+                 pass_attrs: bool = False,
+                 text_description: Optional[str] = None,
+                 kspace_context: Optional[int] = None,
+                 pass_dictionaries: Optional[Dict[str, Dict]] = None,
+                 pass_h5s: Optional[Dict[str, List]] = None,
+                 slice_data: Optional[slice] = None) -> None:
         """
         Initialize the dataset.
 
@@ -77,6 +75,7 @@ class H5SliceData(DirectModule, Dataset):
             is for instance convenient in the validation set of the public Calgary-Campinas dataset as the first 50
             and last 50 slices are excluded in the evaluation.
         """
+        super().__init__()
         self.logger = logging.getLogger(type(self).__name__)
 
         self.root = pathlib.Path(root)

--- a/direct/data/h5_data.py
+++ b/direct/data/h5_data.py
@@ -22,20 +22,22 @@ class H5SliceData(DirectModule, Dataset):
     A PyTorch Dataset class which outputs k-space slices based on the h5 dataformat.
     """
 
-    def __init__(self,
-                 root: pathlib.Path,
-                 filenames_filter: Optional[List[PathOrString]] = None,
-                 regex_filter: Optional[str] = None,
-                 dataset_description: Optional[Dict[PathOrString, Any]] = None,
-                 metadata: Optional[Dict[PathOrString, Dict]] = None,
-                 sensitivity_maps: Optional[PathOrString] = None,
-                 extra_keys: Optional[Tuple] = None,
-                 pass_attrs: bool = False,
-                 text_description: Optional[str] = None,
-                 kspace_context: Optional[int] = None,
-                 pass_dictionaries: Optional[Dict[str, Dict]] = None,
-                 pass_h5s: Optional[Dict[str, List]] = None,
-                 slice_data: Optional[slice] = None) -> None:
+    def __init__(
+        self,
+        root: pathlib.Path,
+        filenames_filter: Optional[List[PathOrString]] = None,
+        regex_filter: Optional[str] = None,
+        dataset_description: Optional[Dict[PathOrString, Any]] = None,
+        metadata: Optional[Dict[PathOrString, Dict]] = None,
+        sensitivity_maps: Optional[PathOrString] = None,
+        extra_keys: Optional[Tuple] = None,
+        pass_attrs: bool = False,
+        text_description: Optional[str] = None,
+        kspace_context: Optional[int] = None,
+        pass_dictionaries: Optional[Dict[str, Dict]] = None,
+        pass_h5s: Optional[Dict[str, List]] = None,
+        slice_data: Optional[slice] = None,
+    ) -> None:
         """
         Initialize the dataset.
 

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -609,14 +609,14 @@ def build_mri_transforms(
 
     mri_transforms = [ToTensor()]
     if mask_func:
-        mri_transforms.append(
+        mri_transforms += [
             CreateSamplingMask(
                 mask_func,
                 shape=crop,
                 use_seed=use_seed,
                 return_acs=estimate_sensitivity_maps,
             )
-        ),
+        ]
 
         # Modify the condition when using precomputed sensitivity maps
         if estimate_sensitivity_maps:

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -133,6 +133,8 @@ class CropAndMask(DirectModule):
             If "uniform" the random cropping will be done by uniformly sampling `crop`, as opposed to `gaussian` which
             will sample from a gaussian distribution.
         """
+        super(CropAndMask, self).__init__()
+
         self.logger = logging.getLogger(type(self).__name__)
 
         self.use_seed = use_seed
@@ -271,6 +273,8 @@ class EstimateSensitivityMap(DirectModule):
         type_of_map: Optional[str] = "unit",
         gaussian_sigma: Optional[float] = None,
     ) -> None:
+        super(EstimateSensitivityMap, self).__init__()
+
         self.backward_operator = backward_operator
         self.kspace_key = kspace_key
         self.type_of_map = type_of_map
@@ -359,6 +363,8 @@ class PadCoilDimension(DirectModule):
         key: tuple
             Key to pad in sample
         """
+        super(PadCoilDimension, self).__init__()
+
         self.num_coils = pad_coils
         self.key = key
 
@@ -408,6 +414,8 @@ class Normalize(DirectModule):
         percentile : float or None
             Rescale data with the given percentile. If None, the division is done by the maximum.
         """
+        super(Normalize, self).__init__()
+
         self.normalize_key = normalize_key
         self.percentile = percentile
 
@@ -486,7 +494,7 @@ class WhitenData(DirectModule):
 
 
 class DropNames(DirectModule):
-    DropNames.__init__(self)
+    super(DropNames, self).__init__()
 
     def __call__(self, sample):
         new_sample = {}
@@ -502,6 +510,8 @@ class DropNames(DirectModule):
 
 class AddNames(DirectModule):
     def __init__(self, add_batch_dimension=True):
+        super(AddNames, self).__init__()
+
         self.add_batch_dimension = add_batch_dimension
 
     def __call__(self, sample):

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -53,6 +53,8 @@ class CreateSamplingMask(DirectModule):
         use_seed=True,
         return_acs=False,
     ):
+        super(CreateSamplingMask, self).__init__()
+
         self.mask_func = mask_func
         self.shape = shape
         self.use_seed = use_seed
@@ -133,7 +135,7 @@ class CropAndMask(DirectModule):
             If "uniform" the random cropping will be done by uniformly sampling `crop`, as opposed to `gaussian` which
             will sample from a gaussian distribution.
         """
-        super(CropAndMask, self).__init__()
+        super(CropAndMask).__init__()
 
         self.logger = logging.getLogger(type(self).__name__)
 

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -135,7 +135,7 @@ class CropAndMask(DirectModule):
             If "uniform" the random cropping will be done by uniformly sampling `crop`, as opposed to `gaussian` which
             will sample from a gaussian distribution.
         """
-        super(CropAndMask).__init__()
+        super(CropAndMask, self).__init__()
 
         self.logger = logging.getLogger(type(self).__name__)
 
@@ -248,6 +248,8 @@ class ComputeImage(DirectModule):
 
 class EstimateBodyCoilImage(DirectModule):
     def __init__(self, mask_func, backward_operator, use_seed=True):
+        super(EstimateBodyCoilImage, self).__init__()
+
         self.mask_func = mask_func
         self.use_seed = use_seed
         self.backward_operator = backward_operator
@@ -461,7 +463,7 @@ class Normalize(DirectModule):
 
 class WhitenData(DirectModule):
     def __init__(self, epsilon=1e-10, key="complex_image"):
-        super().__init__()
+        super(WhitenData, self).__init__()
         self.epsilon = epsilon
         self.key = key
 
@@ -496,7 +498,7 @@ class WhitenData(DirectModule):
 
 
 class DropNames(DirectModule):
-    super(DropNames, self).__init__()
+    super(DropNames).__init__()
 
     def __call__(self, sample):
         new_sample = {}
@@ -534,6 +536,8 @@ class AddNames(DirectModule):
 
 class ToTensor(DirectModule):
     def __init__(self):
+        super(ToTensor, self).__init__()
+
         # 2D and 3D data
         self.names = (["coil", "height", "width"], ["coil", "slice", "height", "width"])
 

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -374,7 +374,7 @@ class PadCoilDimension(DirectModule):
                 f"Tried to pad to {self.num_coils} coils, but already have {curr_num_coils} for "
                 f"{sample['filename']}."
             )
-        elif curr_num_coils == self.num_coils:
+        if curr_num_coils == self.num_coils:
             return sample
 
         shape = data.shape

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -23,6 +23,8 @@ class Compose(DirectModule):
     """
 
     def __init__(self, transforms):
+        super(Compose, self).__init__()
+
         self.transforms = transforms
 
     def __call__(self, sample):

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -210,6 +210,8 @@ class CropAndMask(DirectModule):
 
 class ComputeImage(DirectModule):
     def __init__(self, kspace_key, target_key, backward_operator, type_reconstruction="complex"):
+        super(ComputeImage, self).__init__()
+
         self.backward_operator = backward_operator
         self.kspace_key = kspace_key
         self.target_key = target_key
@@ -484,8 +486,7 @@ class WhitenData(DirectModule):
 
 
 class DropNames(DirectModule):
-    def __init__(self):
-        pass
+    DropNames.__init__(self)
 
     def __call__(self, sample):
         new_sample = {}

--- a/direct/data/tests/test_transforms.py
+++ b/direct/data/tests/test_transforms.py
@@ -88,7 +88,8 @@ def test_fft2(shape, named):
     out_numpy = np.fft.fftshift(out_numpy, (-2, -1))
     z = out_torch - out_numpy
     print(z.real.max(), z.real.min(), z.imag.max(), z.imag.min())
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -114,7 +115,8 @@ def test_ifft2(shape, named):
     input_numpy = np.fft.ifftshift(input_numpy, (-2, -1))
     out_numpy = np.fft.ifft2(input_numpy, norm="ortho")
     out_numpy = np.fft.fftshift(out_numpy, (-2, -1))
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -131,7 +133,8 @@ def test_modulus(shape):
     out_torch = transforms.modulus(data).numpy()
     input_numpy = tensor_to_complex_numpy(data)
     out_numpy = np.abs(input_numpy)
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -145,7 +148,8 @@ def test_root_sum_of_squares_real(shape, dims):
     data = create_input(shape, named=True)  # noqa
     out_torch = transforms.root_sum_of_squares(data, dims).numpy()
     out_numpy = np.sqrt(np.sum(data.numpy() ** 2, dims))
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -164,7 +168,8 @@ def test_root_sum_of_squares_complex(shape, dims):
     out_torch = transforms.root_sum_of_squares(data, dims).numpy()
     input_numpy = tensor_to_complex_numpy(data)
     out_numpy = np.sqrt(np.sum(np.abs(input_numpy) ** 2, dims if not dims == "coils" else 0))
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -179,7 +184,8 @@ def test_root_sum_of_squares_complex(shape, dims):
 def test_center_crop(shape, target_shape, named):
     input = create_input(shape, named=named)
     out_torch = transforms.center_crop(input, target_shape).numpy()
-    assert list(out_torch.shape) == target_shape
+    if list(out_torch.shape) != target_shape:
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -196,9 +202,10 @@ def test_complex_center_crop(shape, target_shape, named):
     input = create_input(shape, named=named)
 
     out_torch = transforms.complex_center_crop(input, target_shape, offset=0).numpy()
-    assert list(out_torch.shape) == target_shape + [
+    if list(out_torch.shape) != target_shape + [
         2,
-    ]
+    ]:
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -232,7 +239,8 @@ def test_roll(shift, dims, shape, named):
     torch_tensor = add_names(torch_tensor, named=named)
     out_torch = transforms.roll(torch_tensor, shift, dims).numpy()
     out_numpy = np.roll(data, shift, dims)
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -254,7 +262,8 @@ def test_complex_multiplication(shape):
 
     out_torch = tensor_to_complex_numpy(transforms.complex_multiplication(torch_tensor_0, torch_tensor_1))
     out_numpy = data_0 * data_1
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -272,7 +281,8 @@ def test_conjugate(shape):
 
     out_torch = tensor_to_complex_numpy(transforms.conjugate(torch_tensor))
     out_numpy = np.conjugate(data)
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize("shape", [[5, 3], [2, 4, 6], [2, 11, 4, 7]])
@@ -289,7 +299,8 @@ def test_fftshift(shape, named):
     torch_tensor = add_names(torch_tensor, named=named)
     out_torch = transforms.fftshift(torch_tensor).numpy()
     out_numpy = np.fft.fftshift(data)
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -313,4 +324,5 @@ def test_ifftshift(shape, named):
     torch_tensor = add_names(torch_tensor, named=named)
     out_torch = transforms.ifftshift(torch_tensor).numpy()
     out_numpy = np.fft.ifftshift(data)
-    assert np.allclose(out_torch, out_numpy)
+    if not np.allclose(out_torch, out_numpy):
+        raise AssertionError

--- a/direct/environment.py
+++ b/direct/environment.py
@@ -235,7 +235,7 @@ def setup_common_environment(
         if key in ["models", "additional_models"]:  # Still handled separately
             continue
 
-        elif key in ["training", "validation", "inference"]:
+        if key in ["training", "validation", "inference"]:
             if not cfg_from_file[key]:
                 logger.info(f"key {key} missing in config.")
                 continue

--- a/direct/functionals/__init__.py
+++ b/direct/functionals/__init__.py
@@ -2,9 +2,9 @@
 # Copyright (c) DIRECT Contributors
 from typing import List
 
-from direct.functionals import psnr
-from direct.functionals import ssim
-from direct.functionals import challenges
+from direct.functionals.psnr import *
+from direct.functionals.ssim import *
+from direct.functionals.challenges import *
 from direct.functionals.regularizer import body_coil
 
 

--- a/direct/inference.py
+++ b/direct/inference.py
@@ -25,6 +25,7 @@ def setup_inference_save_to_h5(
     base_directory,
     output_directory,
     filenames_filter,
+    sensitivity_maps,
     checkpoint,
     device,
     num_workers: int,
@@ -45,6 +46,7 @@ def setup_inference_save_to_h5(
     base_directory :
     output_directory :
     filenames_filter :
+    sensitivity_maps :
     checkpoint :
     device :
     num_workers :
@@ -84,6 +86,7 @@ def setup_inference_save_to_h5(
             checkpoint=checkpoint,
             num_workers=num_workers,
             filenames_filter=curr_filenames_filter,
+            sensitivity_maps=sensitivity_maps,
         )
 
         # Perhaps aggregation to the main process would be most optimal here before writing.
@@ -116,6 +119,7 @@ def inference_on_environment(
     checkpoint,
     num_workers=0,
     filenames_filter=None,
+    sensitivity_maps=None,
 ):
 
     logger.warning("pass_h5s and pass_dictionaries is not yet supported for inference.")
@@ -130,6 +134,7 @@ def inference_on_environment(
         initial_images,
         initial_kspaces,
         filenames_filter,
+        sensitivity_maps,
         data_root,
         pass_dictionaries,
     )

--- a/direct/nn/rim/rim_engine.py
+++ b/direct/nn/rim/rim_engine.py
@@ -26,7 +26,7 @@ from direct.utils import (
     communication,
 )
 from direct.utils.communication import reduce_tensor_dict
-from direct.functionals import SSIMLoss
+from direct.functionals.ssim import SSIMLoss
 from collections import namedtuple
 
 import direct.data.transforms as T

--- a/direct/nn/rim/tests/test_mri_models.py
+++ b/direct/nn/rim/tests/test_mri_models.py
@@ -48,7 +48,6 @@ def add_names(tensor, named=True):
 
 
 from direct.data.transforms import tensor_to_complex_numpy
-from direct.nn.rim.mri_models import MRILogLikelihood
 
 
 input_image = create_input([1, 4, 4, 2]).rename("batch", "height", "width", "complex")

--- a/direct/nn/rim/tests/test_mri_models.py
+++ b/direct/nn/rim/tests/test_mri_models.py
@@ -46,6 +46,7 @@ def add_names(tensor, named=True):
 
     return tensor
 
+
 from direct.data.transforms import tensor_to_complex_numpy
 from direct.nn.rim.mri_models import MRILogLikelihood
 

--- a/direct/utils/__init__.py
+++ b/direct/utils/__init__.py
@@ -122,7 +122,7 @@ def str_to_class(module_name: str, function_name: str) -> Union[object, Callable
 def dict_to_device(
     data: Dict[str, torch.Tensor],
     device: Union[torch.device, str, None],
-    keys: Union[List, Tuple, KeysView, None],
+    keys: Optional[Union[List, Tuple, KeysView]] = None,
 ) -> Dict:
     """
     Copy tensor-valued dictionary to device. Only torch.Tensor is copied.

--- a/direct/utils/asserts.py
+++ b/direct/utils/asserts.py
@@ -38,7 +38,7 @@ def assert_same_shape(data_list: List[torch.Tensor]):
     data_list : list
         List of tensors
     """
-    shape_list = set(_.shape for _ in data_list)
+    shape_list = {_.shape for _ in data_list}
     if not len(shape_list) == 1:
         raise ValueError(f"complex_center_crop expects all inputs to have the same shape. Got {shape_list}.")
 

--- a/direct/utils/asserts.py
+++ b/direct/utils/asserts.py
@@ -70,9 +70,8 @@ def assert_complex(data: torch.Tensor, enforce_named: bool = False, complex_last
     if enforce_named:
         if complex_last and data.names[-1] != "complex":
             raise ValueError(f"Named dimension 'complex' missing, or not at the last axis. Got {data.names}.")
-        else:
-            if "complex" not in data.names:
-                raise ValueError(f"Named dimension 'complex' missing. Got {data.names}.")
+        if "complex" not in data.names:
+            raise ValueError(f"Named dimension 'complex' missing. Got {data.names}.")
 
 
 # TODO(jt): Allow arbitrary list of inputs.

--- a/direct/utils/collate.py
+++ b/direct/utils/collate.py
@@ -5,9 +5,7 @@
 # https://github.com/pytorch/pytorch/blob/00aa23446b9d2b3dac5ed8b343c4536f7d9dd8df/torch/utils/data/_utils/collate.py#L42
 import torch
 
-from torch.utils.data._utils.collate import (
-    default_collate_err_msg_format,
-    np_str_obj_array_pattern)
+from torch.utils.data._utils.collate import default_collate_err_msg_format, np_str_obj_array_pattern
 from torch._six import container_abcs, string_classes, int_classes
 
 

--- a/projects/calgary_campinas/predict_test.py
+++ b/projects/calgary_campinas/predict_test.py
@@ -113,6 +113,11 @@ if __name__ == "__main__":
         type=pathlib.Path,
         help="Path to list of filenames to parse.",
     )
+    parser.add_argument(
+        "--sensitivity_maps",
+        type=pathlib.Path,
+        help="Path to sensitivity_maps.",
+    )
     parser.add_argument("--name", help="Run name.", required=True, type=str)
     parser.add_argument(
         "--cfg",
@@ -148,6 +153,7 @@ if __name__ == "__main__":
         args.experiment_directory,
         args.output_directory,
         args.filenames_filter,
+        args.sensitivity_maps,
         args.checkpoint,
         args.device,
         args.num_workers,

--- a/projects/calgary_campinas/predict_val.py
+++ b/projects/calgary_campinas/predict_val.py
@@ -65,6 +65,11 @@ if __name__ == "__main__":
         help="This is the index of the validation set in the config, e.g., 0 will select the first validation set.",
     )
     parser.add_argument(
+        "--sensitivity_maps",
+        type=pathlib.Path,
+        help="Path to sensitivity_maps.",
+    )
+    parser.add_argument(
         "--filenames-filter",
         type=pathlib.Path,
         help="Path to list of filenames to parse.",
@@ -109,6 +114,7 @@ if __name__ == "__main__":
         args.experiment_directory,
         args.output_directory,
         args.filenames_filter,
+        args.sensitivity_maps,
         args.checkpoint,
         args.device,
         args.num_workers,


### PR DESCRIPTION
This pr allows the following features for inference:
  - loading precomputed sensitivity maps,
  - calculate and pass the mask of the masked kspace, in the case of subsampled data,
  - fix scaling_factor keyword mismatch.