### PR TITLE
Exit when dataset is empty

### DIFF
--- a/direct/data/h5_data.py
+++ b/direct/data/h5_data.py
@@ -133,7 +133,7 @@ class H5SliceData(Dataset):
             if len(filenames) < 5 or idx % (len(filenames) // 5) == 0 or len(filenames) == (idx + 1):
                 self.logger.info(f"Parsing: {(idx + 1) / len(filenames) * 100:.2f}%.")
             try:
-                kspace_shape = h5py.File(filename, "r")["kspace"]  # pylint: disable = E1101
+                kspace_shape = h5py.File(filename, "r")["kspace"].shape  # pylint: disable = E1101
                 self.verify_extra_h5_integrity(filename, kspace_shape, extra_h5s=extra_h5s)  # pylint: disable = E1101
 
             except OSError as exc:

--- a/direct/data/h5_data.py
+++ b/direct/data/h5_data.py
@@ -3,6 +3,7 @@
 import logging
 import pathlib
 import re
+import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import h5py
@@ -99,7 +100,15 @@ class H5SliceData(Dataset):
         if regex_filter:
             filenames = [_ for _ in filenames if re.match(regex_filter, str(_))]
 
-        self.logger.info(f"Using {len(filenames)} h5 files in {self.root}.")
+        if len(filenames) == 0:
+            warn = (
+                f"Found 0 h5 files in directory {self.root}."
+                if not self.text_description
+                else f"Found 0 h5 files in directory {self.root} for dataset {self.text_description}."
+            )
+            self.logger.warning(warn)
+        else:
+            self.logger.info(f"Using {len(filenames)} h5 files in {self.root}.")
 
         self.parse_filenames_data(
             filenames, extra_h5s=pass_h5s, filter_slice=slice_data
@@ -115,7 +124,7 @@ class H5SliceData(Dataset):
         self.ndim = 2 if self.kspace_context == 0 else 3
 
         if self.text_description:
-            self.logger.info("Dataset description: {self.text_description}.")
+            self.logger.info(f"Dataset description: {self.text_description}.")
 
     def parse_filenames_data(self, filenames, extra_h5s=None, filter_slice=None):
         current_slice_number = 0  # This is required to keep track of where a volume is in the dataset
@@ -124,14 +133,14 @@ class H5SliceData(Dataset):
             if len(filenames) < 5 or idx % (len(filenames) // 5) == 0 or len(filenames) == (idx + 1):
                 self.logger.info(f"Parsing: {(idx + 1) / len(filenames) * 100:.2f}%.")
             try:
-                kspace = np.array(h5py.File(filename, "r")["kspace"])
-                self.verify_extra_h5_integrity(filename, kspace.shape, extra_h5s=extra_h5s)
+                kspace_shape = h5py.File(filename, "r")["kspace"]  # pylint: disable = E1101
+                self.verify_extra_h5_integrity(filename, kspace_shape, extra_h5s=extra_h5s)  # pylint: disable = E1101
 
             except OSError as exc:
-                self.logger.warning("{filename} failed with OSError: {exc}. Skipping...", filename=filename, exc=exc)
+                self.logger.warning(f"{filename} failed with OSError: {exc}. Skipping...")
                 continue
 
-            num_slices = kspace.shape[0]
+            num_slices = kspace_shape[0]
             if not filter_slice:
                 self.data += [(filename, _) for _ in range(num_slices)]
 

--- a/direct/engine.py
+++ b/direct/engine.py
@@ -249,7 +249,13 @@ class Engine(ABC, DataDimensionality):
         self.ndim = training_datasets[0].ndim
         self.logger.info(f"Data dimensionality: {self.ndim}.")
 
-        training_data = ConcatDataset(training_datasets)
+        try:
+            training_data = ConcatDataset(training_datasets)
+            if len(training_data) <= 0:
+                raise AssertionError("Concatenated dataset is empty.")
+        except AssertionError as err:
+            self.logger.info(f"{err} Terminating training...")
+            sys.exit(-1)
 
         self.logger.info(f"Concatenated dataset length: {len(training_data)}.")
         self.logger.info(

--- a/direct/engine.py
+++ b/direct/engine.py
@@ -252,9 +252,9 @@ class Engine(ABC, DataDimensionality):
         try:
             training_data = ConcatDataset(training_datasets)
             if len(training_data) <= 0:
-                raise AssertionError("Concatenated dataset is empty.")
+                raise AssertionError("No training data available.")
         except AssertionError as err:
-            self.logger.info(f"{err} Terminating training...")
+            self.logger.info(f"{err}: Terminating training...")
             sys.exit(-1)
 
         self.logger.info(f"Concatenated dataset length: {len(training_data)}.")

--- a/direct/inference.py
+++ b/direct/inference.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Copyright (c) DIRECT Contributors
 import logging
+import sys
 from functools import partial
 from typing import Callable, Optional
 
@@ -131,6 +132,11 @@ def inference_on_environment(
         data_root,
         pass_dictionaries,
     )
+
+    if len(dataset) <= 0:
+        logger.info("Inference dataset is empty. Terminating inference...")
+        sys.exit(-1)
+
     logger.info(f"Inference data size: {len(dataset)}.")
 
     # Run prediction


### PR DESCRIPTION
Changes:
* H5SliceData throws a warning if dataset is empty
* Training is terminated if the concatenated dataset is empty
* Inference is terminated if the detaset is empty