### PR TITLE
Enable to download checkpoint from url for inference

### DIFF
--- a/direct/checkpointer.py
+++ b/direct/checkpointer.py
@@ -68,8 +68,8 @@ class Checkpointer:
         iteration: Union[int, str, None],
         checkpointable_objects: Optional[Dict[str, nn.Module]] = None,
     ) -> Dict:
-        if iteration is not None and not isinstance(iteration, int) and iteration != "latest":
-            raise ValueError("Value `iteration` is expected to be either None, an integer or `latest`.")
+        if iteration is not None and not isinstance(iteration, int) and iteration not in ["latest", "download"]:
+            raise ValueError("Value `iteration` is expected to be either None, an integer, `latest` or 'download'.")
 
         if iteration is None:
             return {}

--- a/direct/config/defaults.py
+++ b/direct/config/defaults.py
@@ -109,6 +109,11 @@ class PhysicsConfig(BaseConfig):
 
 
 @dataclass
+class CheckpointConfig(BaseConfig):
+    checkpoint_url: Optional[str] = None
+
+
+@dataclass
 class DefaultConfig(BaseConfig):
     model: ModelConfig = MISSING
     additional_models: Optional[Any] = None
@@ -118,5 +123,6 @@ class DefaultConfig(BaseConfig):
     training: TrainingConfig = TrainingConfig()  # This should be optional.
     validation: ValidationConfig = ValidationConfig()  # This should be optional.
     inference: Optional[InferenceConfig] = None
+    checkpoint: CheckpointConfig = CheckpointConfig()
 
     logging: LoggingConfig = LoggingConfig()

--- a/direct/inference.py
+++ b/direct/inference.py
@@ -114,7 +114,7 @@ def setup_inference_save_to_h5(
 
         if env.cfg.checkpoint.checkpoint_url is not None:
             import os
-
+            # Delete downloaded checkpoint.
             logger.info(f"Removing {f'model_{checkpoint}.pt'} from {base_directory}...")
             os.remove(base_directory / f"model_{checkpoint}.pt")
 

--- a/direct/inference.py
+++ b/direct/inference.py
@@ -114,6 +114,7 @@ def setup_inference_save_to_h5(
 
         if env.cfg.checkpoint.checkpoint_url is not None:
             import os
+
             # Delete downloaded checkpoint.
             logger.info(f"Removing {f'model_{checkpoint}.pt'} from {base_directory}...")
             os.remove(base_directory / f"model_{checkpoint}.pt")

--- a/direct/inference.py
+++ b/direct/inference.py
@@ -114,6 +114,7 @@ def setup_inference_save_to_h5(
 
         if env.cfg.checkpoint.checkpoint_url is not None:
             import os
+
             logger.info(f"Removing {f'model_{checkpoint}.pt'} from {base_directory}...")
             os.remove(base_directory / f"model_{checkpoint}.pt")
 

--- a/projects/calgary_campinas/predict_test.py
+++ b/projects/calgary_campinas/predict_test.py
@@ -87,6 +87,9 @@ if __name__ == "__main__":
         Run on multiple machines:
             (machine0)$ {sys.argv[0]} data_root output_directory --checkpoint <checkpoint_num> --name <name> --masks <path to masks> --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
             (machine1)$ {sys.argv[0]} data_root output_directory --checkpoint <checkpoint_num> --name <name> --masks <path to masks> --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
+        Download checkpoint from url (checkpoint_url must be specified in config):
+            $ {sys.argv[0]} data_root output_directory --name <name> [--other-flags]
+            If "--checkpoint <checkpoint_num>" is passed it will be ignored.
         """
 
     parser = Args(epilog=epilog)
@@ -100,7 +103,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--checkpoint",
         type=int,
-        required=True,
+        required=False,
         help="Number of an existing checkpoint.",
     )
     parser.add_argument(

--- a/projects/calgary_campinas/predict_val.py
+++ b/projects/calgary_campinas/predict_val.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--checkpoint",
         type=int,
-        required=True,
+        required=False,
         help="Number of an existing checkpoint.",
     )
     parser.add_argument(

--- a/projects/calgary_campinas/predict_val.py
+++ b/projects/calgary_campinas/predict_val.py
@@ -42,11 +42,14 @@ if __name__ == "__main__":
         Run on multiple machines:
             (machine0)$ {sys.argv[0]} data_root output_directory --checkpoint <checkpoint_num> --name <name> --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
             (machine1)$ {sys.argv[0]} data_root output_directory --checkpoint <checkpoint_num> --name <name> --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
+        Download checkpoint from url (checkpoint_url must be specified in config):
+            $ {sys.argv[0]} data_root output_directory --name <name> [--other-flags]
+            If "--checkpoint <checkpoint_num>" is passed it will be ignored.
         """
 
     parser = Args(epilog=epilog)
     parser.add_argument("data_root", type=pathlib.Path, help="Path to the DoIterationOutput directory.")
-    parser.add_argument("output_directory", type=pathlib.Path, help="Path to the DoIterationOutput directory.")
+    parser.add_argument("output_directory", type=pathlib.Path, help="Path to the output directory.")
     parser.add_argument(
         "experiment_directory",
         type=pathlib.Path,


### PR DESCRIPTION
Main changes:

* DefaultConfig allows for checkpoint_url input. Should be a url  that downloads model weights that match with the model configuration in the DefaultConfig
* If url does not correspont to a torch state_dict this will throw an error and exit.
* If `--checkpoint <checkpoint_num>` is passed in the `predict_val.py` and `predict_test.py` whilist checkpoint_url is not null, `--checkpoint <checkpoint_num>` will be ignored